### PR TITLE
chore: Bump `datamodel` to `2.18.0`

### DIFF
--- a/rust/prisma-formatter/Cargo.toml
+++ b/rust/prisma-formatter/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ["cdylib"]
 wasm-bindgen = { version = "0.2.70" }
 getrandom = { version = "0.1.16", features = ["wasm-bindgen"] }
 uuid = { version = "0.8.2", features = ["wasm-bindgen"] }
-datamodel = { git = "https://github.com/prisma/prisma-engines", tag = "2.17.0" }
+datamodel = { git = "https://github.com/prisma/prisma-engines", tag = "2.18.0" }

--- a/rust/prisma-formatter/Cargo.toml
+++ b/rust/prisma-formatter/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { version = "0.2.70" }
+wasm-bindgen = { version = "0.2.71" }
 getrandom = { version = "0.1.16", features = ["wasm-bindgen"] }
 uuid = { version = "0.8.2", features = ["wasm-bindgen"] }
 datamodel = { git = "https://github.com/prisma/prisma-engines", tag = "2.18.0" }


### PR DESCRIPTION
Note: I didn't try it