### PR TITLE
feat: Bump `@prisma/prisma-fmt-wasm` to `4.1.0`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.14.0",
       "license": "MIT",
       "dependencies": {
-        "@prisma/prisma-fmt-wasm": "3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a"
+        "@prisma/prisma-fmt-wasm": "4.1.0-12.09f9659a3d73d5ed2aac8298e2856b8be910cd66"
       },
       "devDependencies": {
         "@types/jest": "27.5.0",
@@ -993,9 +993,9 @@
       }
     },
     "node_modules/@prisma/prisma-fmt-wasm": {
-      "version": "3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a.tgz",
-      "integrity": "sha512-YwiGDAfUqLPz1NIyd6y6LyT1ViiTCXNx7AFWuMwb7aGhBmzhfuTeo/MQpzlA9x90wKh2ACJ4Fa3nZS5Wvr8xbg=="
+      "version": "4.1.0-12.09f9659a3d73d5ed2aac8298e2856b8be910cd66",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.1.0-12.09f9659a3d73d5ed2aac8298e2856b8be910cd66.tgz",
+      "integrity": "sha512-92cZ5P1IcJex6aIxFptU3HNv8g53b/eP0AhqmVGCiyzcTbwCQcbCMUycDuEoHjIuIR0o7XXdHIrXnbiQQMhEGg=="
     },
     "node_modules/@samverschueren/stream-to-observable": {
       "version": "0.3.1",
@@ -8860,9 +8860,9 @@
       }
     },
     "@prisma/prisma-fmt-wasm": {
-      "version": "3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a.tgz",
-      "integrity": "sha512-YwiGDAfUqLPz1NIyd6y6LyT1ViiTCXNx7AFWuMwb7aGhBmzhfuTeo/MQpzlA9x90wKh2ACJ4Fa3nZS5Wvr8xbg=="
+      "version": "4.1.0-12.09f9659a3d73d5ed2aac8298e2856b8be910cd66",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.1.0-12.09f9659a3d73d5ed2aac8298e2856b8be910cd66.tgz",
+      "integrity": "sha512-92cZ5P1IcJex6aIxFptU3HNv8g53b/eP0AhqmVGCiyzcTbwCQcbCMUycDuEoHjIuIR0o7XXdHIrXnbiQQMhEGg=="
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "@prisma/prisma-fmt-wasm": "3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a"
+    "@prisma/prisma-fmt-wasm": "4.1.0-12.09f9659a3d73d5ed2aac8298e2856b8be910cd66"
   },
   "devDependencies": {
     "@types/jest": "27.5.0",


### PR DESCRIPTION
Prisma got upgraded to a major version 4 - so it would be nice to upgrade the plugin too