### PR TITLE
chore: use canonical repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "prettier-plugin",
     "prisma"
   ],
-  "repository": "git@github.com:umidbekk/prettier-plugin-prisma.git",
+  "repository": "git+https://github.com/avocadowastaken/prettier-plugin-prisma.git",
   "license": "MIT",
   "author": "Umidbek Karimov",
   "main": "lib/plugin.js",


### PR DESCRIPTION
## Summary
- update the package repository metadata from the old SSH shorthand URL to the current canonical GitHub HTTPS URL
- leave runtime files, dependencies, package exports, and published file contents unchanged

## Validation
- confirmed npm currently publishes the old SSH repository URL
- checked for existing upstream metadata PRs and Charles microbounty issues before opening this
- node package metadata assertion
- npm ci --ignore-scripts
- npm run checks
- npm pack --dry-run --ignore-scripts --json .
- git diff --check

Note: `npm pack --dry-run --ignore-scripts --json .` still invoked the repository's existing `prepare` hook and installed local Husky hooks, but no tracked files changed.